### PR TITLE
Update adapter for dbt-core 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The `dbt-greenplum` package contains the code enabling dbt to work with Greenplu
 Easiest way to start use dbt-greenplum is to install it using pip
 `pip install dbt-greenplum==<version>`
 
-Where `<version>` is same as your dbt version
+Where `<version>` matches your installed `dbt-core` version (for example `1.10.x`).
 
 Available versions:
  - 0.19.2
@@ -31,6 +31,7 @@ Available versions:
  - 1.2.0
  - 1.4.0
  - 1.5.0
+ - 1.10.0
 
 ## Supported Features
 

--- a/dbt/adapters/greenplum/__init__.py
+++ b/dbt/adapters/greenplum/__init__.py
@@ -1,14 +1,38 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict
+
 from dbt.adapters.greenplum.connections import GreenplumConnectionManager
 from dbt.adapters.greenplum.connections import GreenplumCredentials
 from dbt.adapters.greenplum.impl import GreenplumAdapter
 
-from dbt.adapters.base import AdapterPlugin
+try:  # dbt-core < 1.8
+    from dbt.adapters.base import AdapterPlugin  # type: ignore
+except ImportError:  # dbt-core >= 1.8
+    from dbt.adapters.base.plugin import AdapterPlugin  # type: ignore
+
 from dbt.include import greenplum
 
 
-Plugin = AdapterPlugin(
-    adapter=GreenplumAdapter,
-    credentials=GreenplumCredentials,
-    include_path=greenplum.PACKAGE_PATH,
-    dependencies=['postgres']
-)
+def _plugin_kwargs() -> Dict[str, Any]:
+    signature = inspect.signature(AdapterPlugin)
+    params = signature.parameters
+
+    kwargs: Dict[str, Any] = {
+        "adapter": GreenplumAdapter,
+        "credentials": GreenplumCredentials,
+        "include_path": greenplum.PACKAGE_PATH,
+        "dependencies": ["postgres"],
+    }
+
+    name_keys = ("name", "adapter_name", "adapter_type")
+    for key in name_keys:
+        if key in params:
+            kwargs[key] = "greenplum"
+            break
+
+    return kwargs
+
+
+Plugin = AdapterPlugin(**_plugin_kwargs())

--- a/dbt/adapters/greenplum/__version__.py
+++ b/dbt/adapters/greenplum/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.0"
+version = "1.10.0"

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import os
 import re
 import sys
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 9):
     print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.7 or higher.")
+    print("Please upgrade to Python 3.9 or higher.")
     sys.exit(1)
 
 
@@ -100,7 +100,7 @@ setup(
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
         "dbt-postgres~={}".format(package_version),
-        "{}~=2.8".format(DBT_PSYCOPG2_NAME),
+        "{}~=2.9".format(DBT_PSYCOPG2_NAME),
     ],
     zip_safe=False,
     classifiers=[
@@ -109,12 +109,11 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
 )
 


### PR DESCRIPTION
## Summary
- update package metadata to align with dbt-core 1.10 and Python 3.9+
- make plugin registration compatible with the adapter interface introduced in dbt-core 1.8+
- document the new 1.10.0 release in the README

## Testing
- python -m compileall dbt

------
https://chatgpt.com/codex/tasks/task_e_68d532586a0c833288985fd5effc2099